### PR TITLE
set dropdown values based on SPARQL results

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,14 +54,18 @@
         <div class="form-group">
             <label for="box1" class="col-sm-4 control-label">Genus</label>
             <div class="col-sm-5">
-                <input id="box1" type="text" value="?genus" class="form-control" />
+                <select name="genusDropdown" id="box1" class="form-control">
+                    <option value='?genus' selected='selected'>Any genus</option>
+                </select>
             </div>
         </div>
 
         <div class="form-group">
             <label for="box2" class="col-sm-4 control-label">Species</label>
             <div class="col-sm-5">
-                <input id="box2" type="text" size="30" value="?species" class="form-control" />
+                <select name="speciesDropdown" id="box2" class="form-control">
+                    <option value='?species' selected='selected'>Any species, or select a genus</option>
+                </select>
             </div>
         </div>
 
@@ -69,57 +73,7 @@
             <label for="box3" class="col-sm-4 control-label">State</label>
             <div class="col-sm-5">
                 <select name="stateDropdown" id="box3" class="form-control">
-                    <option value='?state'>All States</option>
-                    <option value='"Alabama"'>Alabama</option>
-                    <option value='"Alaska"'>Alaska</option>
-                    <option value='"Arizona"'>Arizona</option>
-                    <option value='"Arkansas"'>Arkansas</option>
-                    <option value='"California"'>California</option>
-                    <option value='"Colorado"'>Colorado</option>
-                    <option value='"Connecticut"'>Connecticut</option>
-                    <option value='"Delaware"'>Delaware</option>
-                    <option value='"Florida"'>Florida</option>
-                    <option value='"Georgia"'>Georgia</option>
-                    <option value='"Hawaii"'>Hawaii</option>
-                    <option value='"Idaho"'>Idaho</option>
-                    <option value='"Illinois"'>Illinois</option>
-                    <option value='"Indiana"'>Indiana</option>
-                    <option value='"Iowa"'>Iowa</option>
-                    <option value='"Kansas"'>Kansas</option>
-                    <option value='"Kentucky"'>Kentucky</option>
-                    <option value='"Louisiana"'>Louisiana</option>
-                    <option value='"Maine"'>Maine</option>
-                    <option value='"Maryland"'>Maryland</option>
-                    <option value='"Massachusettes"'>Massachusettes</option>
-                    <option value='"Michigan"'>Michigan</option>
-                    <option value='"Minnesota"'>Minnesota</option>
-                    <option value='"Mississippi"'>Mississippi</option>
-                    <option value='"Missouri"'>Missouri</option>
-                    <option value='"Montana"'>Montana</option>
-                    <option value='"Nebraska"'>Nebraska</option>
-                    <option value='"Nevada"'>Nevada</option>
-                    <option value='"New Hampshire"'>New Hampshire</option>
-                    <option value='"New Jersey"'>New Jersey</option>
-                    <option value='"New Mexico"'>New Mexico</option>
-                    <option value='"New York"'>New York</option>
-                    <option value='"North Carolina"'>North Carolina</option>
-                    <option value='"North Dakota"'>North Dakota</option>
-                    <option value='"Ohio"'>Ohio</option>
-                    <option value='"Oklahoma"'>Oklahoma</option>
-                    <option value='"Oregon"'>Oregon</option>
-                    <option value='"Pennsylvania"'>Pennsylvania</option>
-                    <option value='"Rhode Island"'>Rhode Island</option>
-                    <option value='"South Carolina"'>South Carolina</option>
-                    <option value='"South Dakota"'>South Dakota</option>
-                    <option value='"Tennessee"'>Tennessee</option>
-                    <option value='"Texas"'>Texas</option>
-                    <option value='"Utah"'>Utah</option>
-                    <option value='"Vermont"'>Vermont</option>
-                    <option value='"Virginia"'>Virginia</option>
-                    <option value='"Washington"'>Washington</option>
-                    <option value='"West Virginia"'>West Virginia</option>
-                    <option value='"Wisconsn"'>Wisconsin</option>
-                    <option value='"Wyoming"'>Wyoming</option>
+                    <option value='?state' selected='selected'>Any state</option>
                 </select>
             </div>
         </div>
@@ -128,20 +82,7 @@
             <label for="box4" class="col-sm-4 control-label">Category</label>
             <div class="col-sm-5">
                 <select name="categoryDropdown" id="box4" class="form-control">
-                    <option value='?category'>All Anatomical Features</option>
-                    <option value='"bark"'>Bark</option>
-                    <option value='"cone"'>Cone</option>
-                    <option value='"fruit"'>Fruit</option>
-                    <option value='"inflorescence"'>Inflorescence</option>
-                    <option value='"leaf"'>Leaf</option>
-                    <option value='"seed"'>Seed</option>
-                    <option value='"stem"'>Stem</option>
-                    <option value='"twig"'>Twig</option>
-                    <option value='"unspecified"'>Unspecified</option>
-                    <option value='whole gametophyte'>Whole Gametophyte</option>
-                    <option value='"whole plant"'>Whole Plant</option>
-                    <option value='"whole tree"'>Whole Tree</option>
-                    <option value='"whole tree (or vine)"'>Whole Tree (Or Vine)</option>
+                    <option value='?category' selected='selected'>Any Anatomical Feature</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
OK, I hacked the existing query, AJAX function, and XML parser and generated code that would send specific queries to the endpoint to find out the values that exist for genus, state, and category.  I appended each of those values to the option list for the select element.  Each of these routines get called in the Document Ready function. 

 I created one additional hack for the species.  I added an event handler to the Document Ready function for a change in the value of the genus dropdown.  That event handler passes the selected genus to the function that sends the SPARQL query asking for species values that go with only that genus. Then the returned values are used to populate the species options.

It is annoying that there is apparently no way to pass any parameters to the "success:" function in the AJAX routine.  This meant that I had to create four separate parsing functions when I could have easily made one-general purpose one.  Grrr.  Maybe I just missed it...

The major existing flaw in method is that the options aren't alphabetized.  I found some code in Stack Overflow that was supposed to sort options.  However, I couldn't get it to work and I was busy trying to get all the rest of this mess to work.  I left the code commented out near the beginning of the Document Ready function.  Maybe somebody can get it to work.

If you want to test it out to decide if you want to merge the branch, you can download the code from the fork in my GitHub and try it out: https://github.com/baskaufs/bioimages-1 .
